### PR TITLE
DDCYLS-8570 PPT:Previously entered information should persist when using Change links

### DIFF
--- a/app/uk/gov/hmrc/partnershipidentificationfrontend/controllers/CaptureCompanyNumberController.scala
+++ b/app/uk/gov/hmrc/partnershipidentificationfrontend/controllers/CaptureCompanyNumberController.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.http.InternalServerException
 import uk.gov.hmrc.partnershipidentificationfrontend.config.AppConfig
 import uk.gov.hmrc.partnershipidentificationfrontend.controllers.errorpages.{routes => errorRoutes}
 import uk.gov.hmrc.partnershipidentificationfrontend.forms.CaptureCompanyNumberForm
-import uk.gov.hmrc.partnershipidentificationfrontend.service.{CompanyProfileService, JourneyService}
+import uk.gov.hmrc.partnershipidentificationfrontend.service.{CompanyProfileService, JourneyService, PartnershipIdentificationService}
 import uk.gov.hmrc.partnershipidentificationfrontend.utils.MessagesHelper
 import uk.gov.hmrc.partnershipidentificationfrontend.views.html.capture_company_number_page
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -37,6 +37,7 @@ class CaptureCompanyNumberController @Inject()(mcc: MessagesControllerComponents
                                                journeyService: JourneyService,
                                                view: capture_company_number_page,
                                                val authConnector: AuthConnector,
+                                               partnershipIdentificationService: PartnershipIdentificationService,
                                                companyProfileService: CompanyProfileService,
                                                messagesHelper: MessagesHelper
                                               )(implicit val config: AppConfig,
@@ -46,10 +47,16 @@ class CaptureCompanyNumberController @Inject()(mcc: MessagesControllerComponents
     implicit request =>
       authorised().retrieve(internalId) {
         case Some(authInternalId) =>
-          journeyService.getJourneyConfig(journeyId, authInternalId).map {
-            journeyConfig =>
+          for {
+            journeyConfig <- journeyService.getJourneyConfig(journeyId, authInternalId)
+            storedCompanyProfile <- partnershipIdentificationService.retrieveCompanyProfile(journeyId)
+          } yield {
               implicit val messages: Messages = messagesHelper.getRemoteMessagesApi(journeyConfig).preferred(request)
-              Ok(view(journeyConfig.pageConfig, routes.CaptureCompanyNumberController.submit(journeyId), CaptureCompanyNumberForm.form))
+              Ok(view(
+                journeyConfig.pageConfig,
+                routes.CaptureCompanyNumberController.submit(journeyId),
+                storedCompanyProfile.fold(CaptureCompanyNumberForm.form)(profile => CaptureCompanyNumberForm.form.fill(profile.companyNumber))
+              ))
           }
         case None =>
           throw new InternalServerException("Internal ID could not be retrieved from Auth")

--- a/app/uk/gov/hmrc/partnershipidentificationfrontend/controllers/CapturePostCodeController.scala
+++ b/app/uk/gov/hmrc/partnershipidentificationfrontend/controllers/CapturePostCodeController.scala
@@ -45,10 +45,16 @@ class CapturePostCodeController @Inject()(mcc: MessagesControllerComponents,
     implicit request =>
       authorised().retrieve(internalId) {
         case Some(authInternalId) =>
-          journeyService.getJourneyConfig(journeyId, authInternalId).map {
-            journeyConfig =>
+          for {
+            journeyConfig <- journeyService.getJourneyConfig(journeyId, authInternalId)
+            storedPostCode <- partnershipIdentificationService.retrievePostCode(journeyId)
+          } yield {
               implicit val messages: Messages = messagesHelper.getRemoteMessagesApi(journeyConfig).preferred(request)
-              Ok(view(journeyConfig.pageConfig, routes.CapturePostCodeController.submit(journeyId), postCodeForm))
+              Ok(view(
+                journeyConfig.pageConfig,
+                routes.CapturePostCodeController.submit(journeyId),
+                storedPostCode.fold(postCodeForm)(postCodeForm.fill)
+              ))
           }
         case _ =>
           throw new InternalServerException("Internal ID could not be retrieved from Auth")

--- a/app/uk/gov/hmrc/partnershipidentificationfrontend/controllers/CaptureSautrController.scala
+++ b/app/uk/gov/hmrc/partnershipidentificationfrontend/controllers/CaptureSautrController.scala
@@ -47,14 +47,16 @@ class CaptureSautrController @Inject()(mcc: MessagesControllerComponents,
     implicit request =>
       authorised().retrieve(internalId) {
         case Some(authInternalId) =>
-          journeyService.getJourneyConfig(journeyId, authInternalId).map {
-            journeyConfig =>
+          for {
+            journeyConfig <- journeyService.getJourneyConfig(journeyId, authInternalId)
+            storedSautr <- partnershipIdentificationService.retrieveSautr(journeyId)
+          } yield {
               implicit val messages: Messages = messagesHelper.getRemoteMessagesApi(journeyConfig).preferred(request)
               Ok(sautr_view(
                 journeyId,
                 journeyConfig.pageConfig,
                 routes.CaptureSautrController.submit(journeyId),
-                CaptureSautrForm.form,
+                storedSautr.fold(CaptureSautrForm.form)(CaptureSautrForm.form.fill),
                 displayOrNotSkipSautrLink(partnershipType = journeyConfig.partnershipType)))
           }
         case _ =>

--- a/app/uk/gov/hmrc/partnershipidentificationfrontend/controllers/ConfirmPartnershipNameController.scala
+++ b/app/uk/gov/hmrc/partnershipidentificationfrontend/controllers/ConfirmPartnershipNameController.scala
@@ -29,7 +29,7 @@ import uk.gov.hmrc.partnershipidentificationfrontend.views.html.confirm_partners
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 import javax.inject.{Inject, Singleton}
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 @Singleton
 class ConfirmPartnershipNameController @Inject()(mcc: MessagesControllerComponents,
@@ -47,14 +47,17 @@ class ConfirmPartnershipNameController @Inject()(mcc: MessagesControllerComponen
         case Some(authInternalId) =>
           journeyService.getJourneyConfig(journeyId, authInternalId).flatMap {
             journeyConfig =>
-              partnershipIdentificationService.retrieveCompanyProfile(journeyId).map {
+              for {
+                optCompanyProfile <- partnershipIdentificationService.retrieveCompanyProfile(journeyId)
+                optConfirmedPartnershipName <- partnershipIdentificationService.retrieveConfirmedPartnershipName(journeyId)
+              } yield optCompanyProfile match {
                 case Some(companiesHouseInformation) =>
                   implicit val messages: Messages = messagesHelper.getRemoteMessagesApi(journeyConfig).preferred(request)
                   Ok(view(journeyConfig.pageConfig,
                     routes.ConfirmPartnershipNameController.submit(journeyId),
                     companiesHouseInformation.companyName,
                     journeyId,
-                    confirmPartnershipNameForm
+                    optConfirmedPartnershipName.fold(confirmPartnershipNameForm)(confirmPartnershipNameForm.fill)
                   ))
                 case None =>
                   throw new InternalServerException("No company profile stored")
@@ -87,8 +90,10 @@ class ConfirmPartnershipNameController @Inject()(mcc: MessagesControllerComponen
                   }
               },
             formRadio =>
-              if (formRadio) Future.successful(Redirect(routes.CaptureSautrController.show(journeyId)))
-              else Future.successful(Redirect(routes.CaptureCompanyNumberController.show(journeyId)))
+              partnershipIdentificationService.storeConfirmedPartnershipName(journeyId, formRadio).map { _ =>
+                if (formRadio) Redirect(routes.CaptureSautrController.show(journeyId))
+                else Redirect(routes.CaptureCompanyNumberController.show(journeyId))
+              }
           )
         case None =>
           throw new InternalServerException("Internal ID could not be retrieved from Auth")

--- a/app/uk/gov/hmrc/partnershipidentificationfrontend/service/PartnershipIdentificationService.scala
+++ b/app/uk/gov/hmrc/partnershipidentificationfrontend/service/PartnershipIdentificationService.scala
@@ -30,6 +30,11 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class PartnershipIdentificationService @Inject()(connector: PartnershipIdentificationConnector)(implicit ec: ExecutionContext) {
 
+  def storeConfirmedPartnershipName(journeyId: String,
+                                    confirmed: Boolean
+                                   )(implicit hc: HeaderCarrier): Future[SuccessfullyStored.type] =
+    connector.storeData[Boolean](journeyId, PartnershipIdentificationService.ConfirmedPartnershipNameKey, confirmed)
+
   def storeSautr(journeyId: String,
                  sautr: String
                 )(implicit hc: HeaderCarrier): Future[SuccessfullyStored.type] =
@@ -61,6 +66,9 @@ class PartnershipIdentificationService @Inject()(connector: PartnershipIdentific
   def retrievePostCode(journeyId: String)(implicit hc: HeaderCarrier): Future[Option[String]] =
     connector.retrievePartnershipInformation[String](journeyId, PartnershipIdentificationService.PostCodeKey)
 
+  def retrieveConfirmedPartnershipName(journeyId: String)(implicit hc: HeaderCarrier): Future[Option[Boolean]] =
+    connector.retrievePartnershipInformation[Boolean](journeyId, PartnershipIdentificationService.ConfirmedPartnershipNameKey)
+
   def removeSaInformation(journeyId: String)(implicit hc: HeaderCarrier): Future[SuccessfullyRemoved.type] = for {
     _ <- connector.removePartnershipInformation(journeyId, PartnershipIdentificationService.SautrKey)
     _ <- connector.removePartnershipInformation(journeyId, PartnershipIdentificationService.PostCodeKey)
@@ -84,6 +92,7 @@ class PartnershipIdentificationService @Inject()(connector: PartnershipIdentific
 object PartnershipIdentificationService {
   val SautrKey: String = "sautr"
   val PostCodeKey: String = "postcode"
+  val ConfirmedPartnershipNameKey: String = "confirmedPartnershipName"
   val VerificationStatusKey: String = "businessVerification"
   val IdentifiersMatchKey: String = "identifiersMatch"
   val RegistrationKey: String = "registration"

--- a/app/uk/gov/hmrc/partnershipidentificationfrontend/views/confirm_partnership_name_page.scala.html
+++ b/app/uk/gov/hmrc/partnershipidentificationfrontend/views/confirm_partnership_name_page.scala.html
@@ -44,11 +44,13 @@
             items = Seq(
                 RadioItem(
                     content = Text(messages("app.common.yes")),
-                    value = Some("yes")
+                    value = Some("yes"),
+                    checked = form("yes_no").value.contains("yes")
                 ),
                 RadioItem(
                     content = Text(messages("app.common.no")),
-                    value = Some("no")
+                    value = Some("no"),
+                    checked = form("yes_no").value.contains("no")
                 )
             ),
             classes = "govuk-radios--inline",

--- a/it/test/uk/gov/hmrc/partnershipidentificationfrontend/controllers/ConfirmPartnershipNameControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/partnershipidentificationfrontend/controllers/ConfirmPartnershipNameControllerISpec.scala
@@ -42,6 +42,7 @@ class ConfirmPartnershipNameControllerISpec extends ComponentSpecHelper
           journeyConfig = testLimitedPartnershipJourneyConfig(businessVerificationCheck = true)
         ))
         stubRetrieveCompanyProfile(testJourneyId)(status = OK, body = Json.toJsObject(testCompanyProfile))
+        stubRetrieveConfirmedPartnershipName(testJourneyId)(status = NOT_FOUND)
         get(s"$baseUrl/$testJourneyId/confirm-company-name")
       }
       "return OK" in {
@@ -63,6 +64,7 @@ class ConfirmPartnershipNameControllerISpec extends ComponentSpecHelper
                 pageConfig = PageConfig(Some(testCallingServiceName), testDeskProServiceId, testSignOutUrl, testAccessibilityUrl))
             ))
             stubRetrieveCompanyProfile(testJourneyId)(status = OK, body = Json.toJsObject(testCompanyProfile))
+            stubRetrieveConfirmedPartnershipName(testJourneyId)(status = NOT_FOUND)
             get(s"$baseUrl/$testJourneyId/confirm-company-name")
           }
 
@@ -81,6 +83,7 @@ class ConfirmPartnershipNameControllerISpec extends ComponentSpecHelper
             journeyConfig = testLimitedPartnershipJourneyConfig(businessVerificationCheck = true)
           ))
           stubRetrieveCompanyProfile(testJourneyId)(status = NOT_FOUND)
+          stubRetrieveConfirmedPartnershipName(testJourneyId)(status = NOT_FOUND)
           get(s"$baseUrl/$testJourneyId/confirm-company-name")
         }
 
@@ -110,6 +113,7 @@ class ConfirmPartnershipNameControllerISpec extends ComponentSpecHelper
             journeyConfig = testLimitedPartnershipJourneyConfig(businessVerificationCheck = true)
           ))
           stubRetrieveCompanyProfile(testJourneyId)(status = NOT_FOUND)
+          stubRetrieveConfirmedPartnershipName(testJourneyId)(status = NOT_FOUND)
           get(s"$baseUrl/$testJourneyId/confirm-company-name")
         }
 
@@ -125,6 +129,7 @@ class ConfirmPartnershipNameControllerISpec extends ComponentSpecHelper
             journeyConfig = testLimitedPartnershipJourneyConfig(businessVerificationCheck = true)
           ))
           stubRetrieveCompanyProfile(testJourneyId)(status = NOT_FOUND)
+          stubRetrieveConfirmedPartnershipName(testJourneyId)(status = NOT_FOUND)
           get(s"$baseUrl/$testJourneyId/confirm-company-name")
         }
 
@@ -140,6 +145,7 @@ class ConfirmPartnershipNameControllerISpec extends ComponentSpecHelper
             journeyConfig = testLimitedPartnershipJourneyConfig(businessVerificationCheck = true)
           ))
           stubRetrieveCompanyProfile(testJourneyId)(status = NOT_FOUND)
+          stubRetrieveConfirmedPartnershipName(testJourneyId)(status = NOT_FOUND)
           get(s"$baseUrl/$testJourneyId/confirm-company-name")
         }
 
@@ -170,6 +176,7 @@ class ConfirmPartnershipNameControllerISpec extends ComponentSpecHelper
             authInternalId = testInternalId,
             journeyConfig = testLimitedPartnershipJourneyConfig(businessVerificationCheck = true)
           ))
+          stubStoreConfirmedPartnershipName(testJourneyId, confirmedPartnershipName = true)(status = OK)
           post(s"$baseUrl/$testJourneyId/confirm-company-name")("yes_no" -> "yes")
         }
 
@@ -189,6 +196,7 @@ class ConfirmPartnershipNameControllerISpec extends ComponentSpecHelper
             authInternalId = testInternalId,
             journeyConfig = testLimitedPartnershipJourneyConfig(businessVerificationCheck = true)
           ))
+          stubStoreConfirmedPartnershipName(testJourneyId, confirmedPartnershipName = false)(status = OK)
           post(s"$baseUrl/$testJourneyId/confirm-company-name")("yes_no" -> "no")
         }
 
@@ -207,6 +215,7 @@ class ConfirmPartnershipNameControllerISpec extends ComponentSpecHelper
           journeyConfig = testLimitedPartnershipJourneyConfig(businessVerificationCheck = true)
         ))
         stubRetrieveCompanyProfile(testJourneyId)(status = OK, body = Json.toJsObject(testCompanyProfile))
+        stubRetrieveConfirmedPartnershipName(testJourneyId)(status = NOT_FOUND)
         stubAuth(OK, successfulAuthResponse(Some(testInternalId)))
 
         post(s"$baseUrl/$testJourneyId/confirm-company-name")("yes_no" -> "")
@@ -228,6 +237,7 @@ class ConfirmPartnershipNameControllerISpec extends ComponentSpecHelper
             journeyConfig = testLimitedPartnershipJourneyConfig(businessVerificationCheck = true)
           ))
           stubRetrieveCompanyProfile(testJourneyId)(status = NOT_FOUND)
+          stubRetrieveConfirmedPartnershipName(testJourneyId)(status = NOT_FOUND)
           stubAuth(OK, successfulAuthResponse(Some(testInternalId)))
 
           post(s"$baseUrl/$testJourneyId/confirm-company-name")("yes_no" -> "")

--- a/it/test/uk/gov/hmrc/partnershipidentificationfrontend/stubs/PartnershipIdentificationStub.scala
+++ b/it/test/uk/gov/hmrc/partnershipidentificationfrontend/stubs/PartnershipIdentificationStub.scala
@@ -24,6 +24,13 @@ import uk.gov.hmrc.partnershipidentificationfrontend.utils.{WiremockHelper, Wire
 trait PartnershipIdentificationStub extends WiremockMethods {
   implicit private val RegistrationStatusFormat: OFormat[RegistrationStatus] = RegistrationStatus.format
 
+  def stubStoreConfirmedPartnershipName(journeyId: String, confirmedPartnershipName: Boolean)(status: Int): StubMapping =
+    when(method = PUT,
+      uri = s"/partnership-identification/journey/$journeyId/confirmedPartnershipName", body = Json.toJson(confirmedPartnershipName)
+    ).thenReturn(
+      status = status
+    )
+
   def stubStoreSautr(journeyId: String, sautr: String)(status: Int): StubMapping =
     when(method = PUT,
       uri = s"/partnership-identification/journey/$journeyId/sautr", body = JsString(sautr)
@@ -108,6 +115,14 @@ trait PartnershipIdentificationStub extends WiremockMethods {
       body = JsString(body)
     )
   }
+
+  def stubRetrieveConfirmedPartnershipName(journeyId: String)(status: Int, body: Boolean = false): StubMapping =
+    when(method = GET,
+      uri = s"/partnership-identification/journey/$journeyId/confirmedPartnershipName"
+    ).thenReturn(
+      status = status,
+      body = Json.toJson(body)
+    )
 
   def stubRetrievePartnershipDetails(journeyId: String)(status: Int, body: JsValue = Json.obj()): StubMapping =
     when(method = GET,

--- a/test/uk/gov/hmrc/partnershipidentificationfrontend/controllers/CaptureStoredAnswersControllerSpec.scala
+++ b/test/uk/gov/hmrc/partnershipidentificationfrontend/controllers/CaptureStoredAnswersControllerSpec.scala
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.partnershipidentificationfrontend.controllers
+
+import org.jsoup.Jsoup
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{reset, when}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.Application
+import play.api.inject.bind
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.auth.core.retrieve.Retrieval
+import uk.gov.hmrc.partnershipidentificationfrontend.models.PartnershipType.LimitedPartnership
+import uk.gov.hmrc.partnershipidentificationfrontend.models._
+import uk.gov.hmrc.partnershipidentificationfrontend.service.JourneyService
+import uk.gov.hmrc.partnershipidentificationfrontend.service.mocks.MockPartnershipIdentificationService
+
+import scala.concurrent.Future
+import play.api.libs.json.Json
+
+class CaptureStoredAnswersControllerSpec
+    extends AnyWordSpec
+    with Matchers
+    with MockitoSugar
+    with BeforeAndAfterEach
+    with MockPartnershipIdentificationService {
+
+  private val mockAuthConnector: AuthConnector = mock[AuthConnector]
+  private val mockJourneyService: JourneyService = mock[JourneyService]
+
+  private val testJourneyId = "journey-123"
+  private val testInternalId = "internal-123"
+  private val testCompanyName = "Test Partnership LLP"
+  private val testCompanyNumber = "AB123456"
+  private val testSautr = "1234567890"
+  private val testPostCode = "AA1 1AA"
+
+  private val pageConfig = PageConfig(
+    optServiceName = Some("Test Service"),
+    deskProServiceId = "test-service-id",
+    signOutUrl = "/sign-out",
+    accessibilityUrl = "/accessibility",
+    optLabels = None
+  )
+
+  private val journeyConfig = JourneyConfig(
+    continueUrl = "/continue",
+    businessVerificationCheck = false,
+    pageConfig = pageConfig,
+    partnershipType = LimitedPartnership,
+    regime = "VATC"
+  )
+
+  private val companyProfile = CompanyProfile(
+    companyName = testCompanyName,
+    companyNumber = testCompanyNumber,
+    dateOfIncorporation = "2020-01-01",
+    unsanitisedCHROAddress = Json.obj("postal_code" -> testPostCode)
+  )
+
+  private lazy val app: Application =
+    new GuiceApplicationBuilder()
+      .configure(
+        "metrics.enabled" -> false,
+        "metrics.jvm" -> false,
+        "microservice.metrics.graphite.enabled" -> false
+      )
+      .overrides(
+        bind[AuthConnector].toInstance(mockAuthConnector),
+        bind[JourneyService].toInstance(mockJourneyService),
+        bind[uk.gov.hmrc.partnershipidentificationfrontend.service.PartnershipIdentificationService].toInstance(mockPartnershipIdentificationService)
+      )
+      .build()
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+    reset(mockAuthConnector, mockJourneyService)
+    when(
+      mockAuthConnector.authorise[Option[String]](any(), any[Retrieval[Option[String]]]())(any(), any())
+    ).thenReturn(Future.successful(Some(testInternalId)))
+    when(mockJourneyService.getJourneyConfig(testJourneyId, testInternalId)).thenReturn(Future.successful(journeyConfig))
+  }
+
+  private def documentOf(result: Future[play.api.mvc.Result]) =
+    Jsoup.parse(contentAsString(result))
+
+  "CaptureCompanyNumberController.show" should {
+    "pre-populate the stored company number" in {
+      mockRetrieveCompanyProfile(testJourneyId)(Future.successful(Some(companyProfile)))
+
+      val controller = app.injector.instanceOf[CaptureCompanyNumberController]
+      val result = controller.show(testJourneyId)(FakeRequest())
+      val doc = documentOf(result)
+
+      status(result) mustBe OK
+      doc.getElementById("companyNumber").`val`() mustBe testCompanyNumber
+    }
+  }
+
+  "CaptureSautrController.show" should {
+    "pre-populate the stored sautr" in {
+      mockRetrieveSautr(testJourneyId)(Future.successful(Some(testSautr)))
+
+      val controller = app.injector.instanceOf[CaptureSautrController]
+      val result = controller.show(testJourneyId)(FakeRequest())
+      val doc = documentOf(result)
+
+      status(result) mustBe OK
+      doc.getElementById("sa-utr").`val`() mustBe testSautr
+    }
+  }
+
+  "CapturePostCodeController.show" should {
+    "pre-populate the stored postcode" in {
+      mockRetrievePostCode(testJourneyId)(Future.successful(Some(testPostCode)))
+
+      val controller = app.injector.instanceOf[CapturePostCodeController]
+      val result = controller.show(testJourneyId)(FakeRequest())
+      val doc = documentOf(result)
+
+      status(result) mustBe OK
+      doc.getElementById("postcode").`val`() mustBe testPostCode
+    }
+  }
+
+  "ConfirmPartnershipNameController.show" should {
+    "pre-populate the stored yes/no answer" in {
+      mockRetrieveCompanyProfile(testJourneyId)(Future.successful(Some(companyProfile)))
+      mockRetrieveConfirmedPartnershipName(testJourneyId)(Future.successful(Some(true)))
+
+      val controller = app.injector.instanceOf[ConfirmPartnershipNameController]
+      val result = controller.show(testJourneyId)(FakeRequest())
+      val doc = documentOf(result)
+
+      status(result) mustBe OK
+      doc.select("input[name=yes_no][value=yes]").hasAttr("checked") mustBe true
+    }
+  }
+}

--- a/test/uk/gov/hmrc/partnershipidentificationfrontend/service/mocks/MockPartnershipIdentificationService.scala
+++ b/test/uk/gov/hmrc/partnershipidentificationfrontend/service/mocks/MockPartnershipIdentificationService.scala
@@ -52,6 +52,20 @@ trait MockPartnershipIdentificationService extends MockitoSugar with BeforeAndAf
     )(ArgumentMatchers.any[HeaderCarrier])
     ).thenReturn(response)
 
+  def mockRetrievePostCode(journeyId: String)
+                          (response: Future[Option[String]]): OngoingStubbing[_] =
+    when(mockPartnershipIdentificationService.retrievePostCode(
+      ArgumentMatchers.eq(journeyId)
+    )(ArgumentMatchers.any[HeaderCarrier])
+    ).thenReturn(response)
+
+  def mockRetrieveConfirmedPartnershipName(journeyId: String)
+                                          (response: Future[Option[Boolean]]): OngoingStubbing[_] =
+    when(mockPartnershipIdentificationService.retrieveConfirmedPartnershipName(
+      ArgumentMatchers.eq(journeyId)
+    )(ArgumentMatchers.any[HeaderCarrier])
+    ).thenReturn(response)
+
   def mockRetrieveBusinessVerificationResponse(journeyId: String)
                                               (response: Future[Option[BusinessVerificationStatus]]): OngoingStubbing[_] =
     when(mockPartnershipIdentificationService.retrieveBusinessVerificationStatus(


### PR DESCRIPTION
Changes - 

Retain partnership journey answers when navigating from check your answers

- amended CaptureCompanyNumberController.scala
- amended CapturePostCodeController.scala
- amended CaptureSautrController.scala
- amended ConfirmPartnershipNameController.scala
- amended PartnershipIdentificationService.scala
- amended confirm_partnership_name_page.scala.html
- amended MockPartnershipIdentificationService.scala amended CaptureStoredAnswersControllerSpec.scala

Related PR's - 

- https://github.com/hmrc/plastic-packaging-tax-registration-frontend/pull/651
- https://github.com/hmrc/incorporated-entity-identification-frontend/pull/244
- https://github.com/hmrc/sole-trader-identification-frontend/pull/257